### PR TITLE
Restore signing for Gradle release publishes and add GPG fallback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,10 +77,19 @@ publishing {
 }
 
 signing {
+    def isReleaseVersion = !version.endsWith('SNAPSHOT')
     def signingKey = findProperty('signingKey') ?: System.getenv('SIGNING_KEY')
     def signingPassword = findProperty('signingPassword') ?: System.getenv('SIGNING_PASSWORD')
+
+    required = isReleaseVersion && gradle.taskGraph.allTasks.any { task ->
+        task.name == 'publish' || task.name.startsWith('publish')
+    }
+
     if (signingKey) {
         useInMemoryPgpKeys(signingKey, signingPassword)
-        sign publishing.publications.mavenJava
+    } else {
+        useGpgCmd()
     }
+
+    sign publishing.publications.mavenJava
 }


### PR DESCRIPTION
### Motivation
- After migrating from Maven, release publishes could be performed unsigned when no in-memory key was provided, causing Sonatype staging uploads to be rejected; this change ensures release publishing requires signing and restores support for local GPG setups.

### Description
- Update the `signing` block in `build.gradle` to compute `isReleaseVersion` and make signing `required` when a `publish` task (or task starting with `publish`) is executed for a non-`SNAPSHOT` version.
- Preserve `useInMemoryPgpKeys` for CI by using `signingKey` when provided and add `useGpgCmd()` as a fallback when no in-memory key is supplied.
- Always call `sign publishing.publications.mavenJava` so the `mavenJava` publication is signed in both CI and local GPG workflows.

### Testing
- Attempted to run `./gradlew test` but the Gradle wrapper download was blocked by a proxy, producing an `HTTP/1.1 403 Forbidden`, so the test run could not complete.
- Performed a local inspection of `build.gradle` and verified the `signing` block contains the `required` condition and the `useGpgCmd()` fallback as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab473f4a083298688dc907522b80a)